### PR TITLE
Align default DocumentHub base path with user directory

### DIFF
--- a/README_SystemMap.md
+++ b/README_SystemMap.md
@@ -1,6 +1,6 @@
 ﻿# The VLSC Document Hub
 
-Base path: D:\OneDrive - The VLSC\The_VLSC_DocumentHub
+Base path: C:\\Users\\mchri\\OneDrive - The VLSC\\The_VLSC_DocumentHub
 
 This hub is processed by a local Python worker and routed by Power Automate.
 Only **01_Processing\Staging** is watched by Power Automate.

--- a/Setup_VLSC_DocumentHub.ps1
+++ b/Setup_VLSC_DocumentHub.ps1
@@ -3,10 +3,10 @@
 
 $ErrorActionPreference = "Stop"
 
-# -------- SETTINGS --------
-$BasePath   = "D:\OneDrive - The VLSC\The_VLSC_DocumentHub"
-$PythonCmd  = "python"
-# --------------------------
+param(
+    [string]$BasePath  = "C:\\Users\\mchri\\OneDrive - The VLSC\\The_VLSC_DocumentHub",
+    [string]$PythonCmd = "python"
+)
 
 Write-Host "Base path: $BasePath"
 


### PR DESCRIPTION
## Summary
- switch Setup_VLSC_DocumentHub.ps1 to accept a BasePath parameter defaulting to the OneDrive user directory
- update the system map README to reflect the new default base path

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b45d8383483278af6dfac9ec08e6b)