### PR TITLE
Add Cloudflare email worker for books address

### DIFF
--- a/cloudflare_email_worker.js
+++ b/cloudflare_email_worker.js
@@ -1,0 +1,51 @@
+export default {
+  /**
+   * Email Worker handler for books@thevlsc.com
+   *
+   * Expected environment variables:
+   * - FORWARD_TO: destination address to forward every accepted message to
+   * - INTAKE_WEBHOOK_URL (optional): HTTPS endpoint to receive a JSON summary
+   */
+  async email(message, env, ctx) {
+    const receivedAt = new Date().toISOString();
+    const subject = message.headers.get("subject") || "(no subject)";
+    const from = message.from || "";
+    const to = message.to || "";
+    const replyTo = message.headers.get("reply-to") || "";
+
+    const summary = {
+      receivedAt,
+      envelope: { from, to },
+      headers: { subject, replyTo },
+      size: message.rawSize,
+    };
+
+    if (env.INTAKE_WEBHOOK_URL) {
+      const payload = JSON.stringify(summary);
+      ctx.waitUntil(
+        fetch(env.INTAKE_WEBHOOK_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: payload,
+        }).catch((err) => {
+          console.error("Failed to post intake webhook", err);
+        })
+      );
+    }
+
+    if (env.FORWARD_TO) {
+      try {
+        await message.forward(env.FORWARD_TO);
+        return;
+      } catch (err) {
+        console.error(`Forwarding to ${env.FORWARD_TO} failed`, err);
+        message.setReject(`Unable to forward inbound email: ${err}`);
+        return;
+      }
+    }
+
+    message.setReject("No FORWARD_TO address configured for books@thevlsc.com");
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,16 @@
+name = "vlsc-books-email"
+main = "cloudflare_email_worker.js"
+compatibility_date = "2024-08-01"
+
+# Replace with your Cloudflare account ID before deploying
+account_id = "<your-account-id>"
+
+[[routes]]
+pattern = "books@thevlsc.com"
+type = "email"
+
+[vars]
+# Forwarding target for incoming messages to books@thevlsc.com
+FORWARD_TO = "books@thevlsc.com"
+# Optional: webhook to receive structured metadata for downstream processing
+INTAKE_WEBHOOK_URL = "https://example.com/hooks/books"


### PR DESCRIPTION
## Summary
- add a Cloudflare Email Worker to handle mail sent to books@thevlsc.com, forward it, and optionally post metadata to a webhook
- include a wrangler.toml template binding the books@thevlsc.com email route with configurable environment variables

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693bb11756a483278a75dddf3999dae8)