### PR TITLE
Add multi-company processing paths

### DIFF
--- a/email_ingestion.py
+++ b/email_ingestion.py
@@ -33,6 +33,12 @@ PROCESSED_DIRS = {
     "CLIENT": BASE_DATA_DIR / "processed" / "client",
     "ADMIN": BASE_DATA_DIR / "processed" / "admin",
     "ARCHIVE": BASE_DATA_DIR / "processed" / "archive",
+    # Company-specific processed folders for multi-tenant routing.
+    "NSP": BASE_DATA_DIR / "processed" / "nsp",  # Norscape Properties
+    "RLI": BASE_DATA_DIR / "processed" / "rli",  # Richardson Landscape Inc.
+    "FDP": BASE_DATA_DIR / "processed" / "fdp",  # Felix Diaz personal
+    "PERSONAL": BASE_DATA_DIR / "processed" / "personal",  # Family documents
+    "UNSORTED": BASE_DATA_DIR / "unsorted",
 }
 DB_PATH = BASE_DATA_DIR / "document_routes.db"
 

--- a/worker_main.py
+++ b/worker_main.py
@@ -19,8 +19,10 @@ CONFIG_PATH = BASE_DIR / "Rules" / "worker_config.json"
 
 DEFAULT_CONFIG = {
     "paths": {
-        "raw_scans_dir": str(BASE_DIR / "data" / "incoming"),
-        "needs_review_dir": str(BASE_DIR / "data" / "needs_review"),
+        "raw_scans_dir": str(BASE_DIR / "data" / "intake_queue"),
+        "unsorted_dir": str(BASE_DIR / "data" / "unsorted"),
+        "needs_review_dir": str(BASE_DIR / "data" / "unsorted"),
+        "raw_backup_dir": str(BASE_DIR / "data" / "raw_backup"),
         "duplicate_hold_dir": str(BASE_DIR / "data" / "duplicate_hold"),
         "ocr_text_dir": str(BASE_DIR / "data" / "ocr_text"),
         "staging_dir": str(BASE_DIR / "data" / "staging"),
@@ -28,6 +30,17 @@ DEFAULT_CONFIG = {
         "logs_dir": str(BASE_DIR / "logs"),
         "rules_file": str(BASE_DIR / "Rules" / "routing_rules.json"),
         "personal_storage_dir": str(BASE_DIR / "data" / "personal" / "secure"),
+        "processed_dirs": {
+            "ap": str(BASE_DIR / "data" / "processed" / "ap"),
+            "ar": str(BASE_DIR / "data" / "processed" / "ar"),
+            "client": str(BASE_DIR / "data" / "processed" / "client"),
+            "admin": str(BASE_DIR / "data" / "processed" / "admin"),
+            "archive": str(BASE_DIR / "data" / "processed" / "archive"),
+            "nsp": str(BASE_DIR / "data" / "processed" / "nsp"),
+            "rli": str(BASE_DIR / "data" / "processed" / "rli"),
+            "fdp": str(BASE_DIR / "data" / "processed" / "fdp"),
+            "personal": str(BASE_DIR / "data" / "processed" / "personal"),
+        },
     },
     "logging": {
         "csv_log": str(BASE_DIR / "logs" / "worker_log.csv"),
@@ -35,6 +48,8 @@ DEFAULT_CONFIG = {
         "metadata_store": str(BASE_DIR / "logs" / "documents.db"),
     },
     "classification": {"min_confidence": 0.5},
+    "unsorted_review": {"cron": "0 21 * * SUN", "enabled": True},
+    "ocr": {"fallback_chain": ["capture_touch", "acrobat", "tesseract"]},
     "polling": {
         "interval_seconds": 10,
         "stability_check_seconds": 2,
@@ -55,15 +70,22 @@ CONFIG = load_config()
 
 # Paths
 PATHS = CONFIG["paths"]
-RAW_SCANS_DIR = Path(PATHS["raw_scans_dir"])
-NEEDS_REVIEW_DIR = Path(PATHS["needs_review_dir"])
-DUPLICATE_HOLD_DIR = Path(PATHS["duplicate_hold_dir"])
-OCR_TEXT_DIR = Path(PATHS["ocr_text_dir"])
-STAGING_DIR = Path(PATHS["staging_dir"])
-TEMP_DIR = Path(PATHS["temp_dir"])
-LOGS_DIR = Path(PATHS["logs_dir"])
-RULES_FILE = Path(PATHS["rules_file"])
-PERSONAL_STORAGE_DIR = Path(PATHS["personal_storage_dir"])
+RAW_SCANS_DIR = Path(PATHS.get("raw_scans_dir", BASE_DIR / "data" / "incoming"))
+UNSORTED_DIR = Path(
+    PATHS.get("unsorted_dir", PATHS.get("needs_review_dir", BASE_DIR / "data" / "unsorted"))
+)
+NEEDS_REVIEW_DIR = Path(PATHS.get("needs_review_dir", UNSORTED_DIR))
+RAW_BACKUP_DIR = Path(PATHS.get("raw_backup_dir", BASE_DIR / "data" / "raw_backup"))
+DUPLICATE_HOLD_DIR = Path(PATHS.get("duplicate_hold_dir", BASE_DIR / "data" / "duplicate_hold"))
+OCR_TEXT_DIR = Path(PATHS.get("ocr_text_dir", BASE_DIR / "data" / "ocr_text"))
+STAGING_DIR = Path(PATHS.get("staging_dir", BASE_DIR / "data" / "staging"))
+TEMP_DIR = Path(PATHS.get("temp_dir", BASE_DIR / "data" / "temp"))
+LOGS_DIR = Path(PATHS.get("logs_dir", BASE_DIR / "logs"))
+RULES_FILE = Path(PATHS.get("rules_file", BASE_DIR / "Rules" / "routing_rules.json"))
+PERSONAL_STORAGE_DIR = Path(
+    PATHS.get("personal_storage_dir", BASE_DIR / "data" / "personal" / "secure")
+)
+PROCESSED_COMPANY_DIRS = PATHS.get("processed_dirs", {})
 
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- add company-specific processed directory mappings in the ingestion pipeline
- expand worker default configuration with unsorted/raw backup paths and per-company folders
- include configuration defaults for unsorted review scheduling and OCR fallback chain

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b38c5cee08327aaaf6c738d0c53cb)