### PR TITLE
Add duplicate detection to email ingestion

### DIFF
--- a/PROCESS_FLOW.md
+++ b/PROCESS_FLOW.md
@@ -20,6 +20,7 @@ This document describes the end-to-end file processing path for files received a
 4. Build metadata and determine route
    - `build_metadata_hash()` computes a SHA256 hash of extracted text + file bytes.
    - `determine_route_hint()` inspects extracted text for keywords (invoice, receipt, contract, policy) to suggest `AP`, `AR`, `CLIENT`, `ADMIN`, or `ARCHIVE`.
+   - If a metadata hash already exists in `document_routes.db`, the attachment is treated as a duplicate and archived with a QR stamp without calling the worker.
 
 5. Generate QR payload & stamp file
    - QR payload created by `_qr_payload()` and rendered via `_qr_image()` (qrcode lib).

--- a/email_ingestion.py
+++ b/email_ingestion.py
@@ -110,6 +110,13 @@ class DatabaseClient:
                 ),
             )
 
+    def has_metadata_hash(self, metadata_hash: str) -> bool:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM document_routes WHERE metadata_hash = ? LIMIT 1", (metadata_hash,)
+            )
+            return cur.fetchone() is not None
+
 
 class EmailIngestor:
     def __init__(self, config: EmailIngestionConfig):
@@ -358,6 +365,30 @@ def process_attachment(attachment: AttachmentRecord, config: EmailIngestionConfi
     route_hint = determine_route_hint(text)
     doc_type = attachment.subject or "email-attachment"
     payload = _qr_payload(doc_type, metadata_hash, route_hint)
+
+    if db.has_metadata_hash(metadata_hash):
+        logging.info("Skipping duplicate attachment %s (metadata hash match)", attachment.filename)
+        stamped_path = stamp_with_qr(attachment.local_path, payload)
+        archive_dir = PROCESSED_DIRS["ARCHIVE"]
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        destination = archive_dir / f"duplicate_{stamped_path.name}"
+        if destination.exists():
+            destination = archive_dir / f"duplicate_{int(time.time())}_{stamped_path.name}"
+        shutil.move(stamped_path, destination)
+        db.record(
+            original_filename=attachment.filename,
+            final_filename=destination.name,
+            route="DUPLICATE",
+            location=str(destination.parent),
+            metadata_hash=metadata_hash,
+            qr_payload=payload,
+        )
+        try:
+            attachment.local_path.unlink(missing_ok=True)
+            logging.info("Removed intake copy %s after duplicate detection", attachment.local_path)
+        except Exception as exc:
+            logging.warning("Failed to remove intake file %s: %s", attachment.local_path, exc)
+        return destination
 
     stamped_path = stamp_with_qr(attachment.local_path, payload)
     metadata = {


### PR DESCRIPTION
## Summary
- add database helper to detect previously processed metadata hashes
- skip sending attachments to the worker when duplicates are found and archive them with QR stamps
- document the duplicate flow in PROCESS_FLOW.md

## Testing
- python -m compileall email_ingestion.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b3a1910a08327ac8dc230cdbe4f88)